### PR TITLE
fix update-initramfs 'Exec format error'

### DIFF
--- a/kernel_update.sh
+++ b/kernel_update.sh
@@ -325,7 +325,8 @@ do_ubuntu_kernel_update() {
 	fi
 
 	if [ -f /etc/initramfs/post-update.d/flash-kernel ]; then
-		echo "exit 0" > /etc/initramfs/post-update.d/flash-kernel
+		echo '#!/bin/bash' > /etc/initramfs/post-update.d/flash-kernel
+		echo "exit 0" >> /etc/initramfs/post-update.d/flash-kernel
 		chmod +x /etc/initramfs/post-update.d/flash-kernel
 	fi
 	


### PR DESCRIPTION
Without "shebang" update-initramfs make an error.

Without => 
# update-initramfs -u

update-initramfs: Generating /boot/initrd.img-3.8.13.28
run-parts: failed to exec /etc/initramfs/post-update.d//flash-kernel: Exec format error
run-parts: /etc/initramfs/post-update.d//flash-kernel exited with return code 1
# 

With => 
# update-initramfs -u

update-initramfs: Generating /boot/initrd.img-3.8.13.28
# 
