### PR TITLE
Kernel update features

### DIFF
--- a/createsym.sh
+++ b/createsym.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+PWD=($PWD)
+FILES=`ls *.sh`
+for FILE in $FILES; do
+	rm -f /usr/local/bin/$FILE
+	ln -s $PWD/$FILE /usr/local/bin/$FILE	
+done
+echo "/usr/local/bin shell scripts related to odroid utility have been removed and replaced with sym links at $PWD"
+
+

--- a/fs_resize.sh
+++ b/fs_resize.sh
@@ -38,6 +38,7 @@ resize_p2() {
 	sleep 4
 	
 	p2_start=`fdisk -l /dev/mmcblk0 | grep mmcblk0p2 | awk '{print $2}'`
+	p2_finish=$((`fdisk -l /dev/mmcblk0 | grep total | grep sectors | awk '{printf $8}'` - 1024))
 	
 	fdisk /dev/mmcblk0 <<EOF &>> $rsflog
 p
@@ -47,7 +48,7 @@ n
 p
 2
 $p2_start
-
+$p2_finish
 p
 w
 EOF

--- a/odroid-utility.sh
+++ b/odroid-utility.sh
@@ -7,9 +7,15 @@
 
 # Global defines
 _B="/usr/local/bin"
+_CUR_VER="1.4"
+
+
+# Allow overriding of updates
+BOOTSTRAP="${BOOTSTRAP:=1}"
+INTERNALS="${INTERNALS:=1}"
 
 initialization() {
-	
+
 		if [ `whoami` != "root" ]; then
 			echo "You must run the app as root."
 			echo "sudo $0"
@@ -24,8 +30,8 @@ initialization() {
                         export DISTRO="ubuntu"
                         ;;
                 "Debian")
-						export DISTRO="debian"
-						;;
+			export DISTRO="debian"
+			;;
                 *)
                         echo "I couldn't identify your distribution."
                         echo "Please report this error on the forums"
@@ -37,17 +43,44 @@ initialization() {
                 esac
 
         # now that we know what we are running, lets grab all the OS Packages that we need.
+	if [ $BOOTSTRAP -eq 1 ]; then
+		install_bootstrap_packages
+     		fi
 
-	install_bootstrap_packages
-      
-	update_internals
+	if [ $INTERNALS -eq 1 ]; then
+		update_internals
+	fi
 
-		if [ -f $_B/config.sh ]; then
-			source $_B/config.sh
+	#Update version information	
+
+	SOURCE_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+		
+	GITHUB_REV=`curl -s https://api.github.com/repos/mdrjr/odroid-utility/git/refs/heads/master | awk '{ if ($1 == "\"sha\":") { print substr($2, 2, 40) } }'`
+		
+	#if they are running it from expected location and its not a sym link then just use github rev
+	if [ $SOURCE_DIR == "/usr/local/bin" ] && ! [ -L $BASH_SOURCE ]; then
+		APP_REV=$GITHUB_REV
+	else
+		if hash git 2>/dev/null; then
+			APP_REV=$(git rev-parse --verify HEAD)
+			if [ $APP_REV != $GITHUB_REV ]; then
+				APP_REV="$APP_REV (Developer)"
+			fi
 		else
-			echo "Error. Couldn't start"
-			exit 0
+			#Shouldn't happen - git wasn't installed 
+			APP_REV="<Uknown Version>"
 		fi
+	fi
+
+
+	export _REV="$_CUR_VER GitRev: $APP_REV"
+
+	if [ -f $_B/config.sh ]; then
+		source $_B/config.sh
+	else
+		echo "Error. Couldn't start"
+		exit 0
+	fi
 }
 
 install_bootstrap_packages() {
@@ -71,20 +104,18 @@ install_bootstrap_packages() {
 update_internals() {
 	echo "Performing scripts updates"
 	baseurl="https://raw.githubusercontent.com/mdrjr/odroid-utility/master"
-	
+
 	FILES=`curl -s $baseurl/files.txt`
-	APP_REV=`curl -s https://api.github.com/repos/mdrjr/odroid-utility/git/refs/heads/master | awk '{ if ($1 == "\"sha\":") { print substr($2, 2, 40) } }'`
-	
+
 	for fu in $FILES; do
 		echo "Updating: $fu"
 		rm -fr $_B/$fu
 		curl -s $baseurl/$fu > $_B/$fu
 	done
 
-	export _REV="1.4 GitRev: $APP_REV"
-	
 	chmod +x $_B/odroid-utility.sh
 }
 
 # Start the script
 initialization
+


### PR DESCRIPTION
- Check for Kernel updates before downloading
- Restore backups using GUI
- Bypass updating at startup with toggling env vars BOOTSTRAP and INTERNALS to 0
- Showing if the version is in "developer" mode - aka not matching one on mdrjr master
- createsym.sh to replace all scripts in /usr/bin/local with those in the current directory (e.g useful when you have just cloned odroid repo down and you want /usr/bin/local to point to it.
